### PR TITLE
Upgrade wdio-sync to support node@12

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "mocha": "^5.2.0",
-    "wdio-sync": "0.7.3"
+    "wdio-sync": "5.9.6"
   },
   "devDependencies": {
     "babel-cli": "~6.26.0",


### PR DESCRIPTION
fiber@4, a dependency of wdio-sync, is required. See https://github.com/laverdet/node-fibers/issues/409